### PR TITLE
Setup Prisma and NextAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DATABASE_URL=postgresql://linkhub:linkhub@localhost:5432/linkhub
+NEXTAUTH_SECRET=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /usr/src/app
+COPY package.json pnpm-lock.yaml ./
+RUN corepack enable && pnpm install
+COPY . .
+EXPOSE 3000
+CMD ["pnpm","dev","-p","3000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: linkhub
+      POSTGRES_USER: linkhub
+      POSTGRES_PASSWORD: linkhub
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U linkhub"]
+      interval: 5s
+      retries: 5
+
+  # Facultatif : exécuter l’app dans Docker en dev
+  # (sinon tu lances `pnpm dev` sur l’hôte)
+  app:
+    build:
+      context: .
+      dockerfile: dev.Dockerfile          # ⬅︎ seulement pour DEV
+    command: ["pnpm","dev","-p","3000"]
+    volumes:
+      - ./:/usr/src/app
+      - /usr/src/app/node_modules
+    environment:
+      DATABASE_URL: postgres://linkhub:linkhub@db:5432/linkhub
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+    ports:
+      - "3000:3000"
+    depends_on:
+      db: { condition: service_healthy }
+
+volumes:
+  pgdata:

--- a/prisma/migrations/00000000000000_init/migration.sql
+++ b/prisma/migrations/00000000000000_init/migration.sql
@@ -1,0 +1,20 @@
+CREATE TYPE "Role" AS ENUM ('OWNER', 'ADMIN', 'USER');
+
+CREATE TABLE "Tenant" (
+  "id" TEXT NOT NULL,
+  "slug" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  CONSTRAINT "Tenant_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "User" (
+  "id" TEXT NOT NULL,
+  "email" TEXT NOT NULL,
+  "tenantId" TEXT NOT NULL,
+  "role" "Role" NOT NULL DEFAULT 'USER',
+  CONSTRAINT "User_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "User_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "Tenant_slug_key" ON "Tenant"("slug");
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");

--- a/prisma/migrations/00000000000001_enable_rls/sql
+++ b/prisma/migrations/00000000000001_enable_rls/sql
@@ -1,0 +1,10 @@
+ALTER TABLE "Tenant" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "User"   ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation_tenant
+  ON "Tenant"
+  USING (id = current_setting('app.tenant_id')::text);
+
+CREATE POLICY tenant_isolation_user
+  ON "User"
+  USING (tenant_id = current_setting('app.tenant_id')::text);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,23 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client { provider = "prisma-client-js" }
+
+model Tenant {
+  id     String @id @default(cuid())
+  slug   String @unique
+  name   String
+  users  User[]
+}
+
+model User {
+  id       String @id @default(cuid())
+  email    String @unique
+  tenantId String
+  tenant   Tenant @relation(fields: [tenantId], references: [id])
+  role     Role   @default(USER)
+}
+
+enum Role { OWNER ADMIN USER }

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,1 @@
+export { handlers as GET, handlers as POST } from "@/auth";

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,29 @@
+import NextAuth from "next-auth";
+import Google from "next-auth/providers/google";
+import { PrismaAdapter } from "@auth/prisma-adapter";
+import { db } from "@/lib/db";
+
+export const { handlers, auth } = NextAuth({
+  adapter: PrismaAdapter(db),
+  providers: [
+    Google({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    }),
+  ],
+  session: { strategy: "jwt" },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.tenantId = (user as any).tenantId;
+        token.role = (user as any).role;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      (session as any).user.tenantId = token.tenantId as string;
+      (session as any).user.role = token.role as string;
+      return session;
+    },
+  },
+});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from '@prisma/client'
+
+export const db = new PrismaClient({
+  log: ['error']
+})

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import postgres from "postgres";
+
+const sql = postgres(process.env.DATABASE_URL!, { idle_timeout: 2 });
+
+export async function middleware() {
+  const session = await auth();
+  const id = session?.user?.tenantId ?? "public";
+  await sql`SELECT set_config('app.tenant_id', ${id}, true)`;
+  return NextResponse.next();
+}
+
+export const config = { matcher: ["/((?!api/auth|_next|favicon).*)"] };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
       }
     ],
     "paths": {
-      "@/lib/*": ["./src/*"]
+      "@/lib/*": ["./src/lib/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- add docker-compose for Postgres and dev container
- include sample environment file
- configure Prisma schema with migrations
- set up NextAuth authentication and middleware
- fix path alias in tsconfig

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d46feedc08327a54846b3e1b30043